### PR TITLE
Add developer Israel SB to developer file

### DIFF
--- a/developers.txt
+++ b/developers.txt
@@ -8,3 +8,4 @@
 - Amanda Suárez Jacobo
 - Alan Gerardo Cid Díaz
 - Bryan Iván Castillo Navarrete
+- Israel Sánchez Badillo


### PR DESCRIPTION
- Added a new developer entry to `developers.txt`.
- The name **Israel Sánchez Badillo** was appended to the existing list of developers.
- No other modifications were made to the file.